### PR TITLE
feat: [MOB-121] Add LinkDomain to ActionCodeSettings

### DIFF
--- a/auth/email_action_links.go
+++ b/auth/email_action_links.go
@@ -31,6 +31,7 @@ type ActionCodeSettings struct {
 	AndroidPackageName    string `json:"androidPackageName,omitempty"`
 	AndroidMinimumVersion string `json:"androidMinimumVersion,omitempty"`
 	AndroidInstallApp     bool   `json:"androidInstallApp,omitempty"`
+	LinkDomain            string `json:"linkDomain,omitempty"`
 	DynamicLinkDomain     string `json:"dynamicLinkDomain,omitempty"`
 }
 

--- a/auth/email_action_links_test.go
+++ b/auth/email_action_links_test.go
@@ -35,6 +35,7 @@ var testActionLinkResponse = []byte(fmt.Sprintf(testActionLinkFormat, testAction
 var testActionCodeSettings = &ActionCodeSettings{
 	URL:                   "https://example.dynamic.link",
 	HandleCodeInApp:       true,
+	LinkDomain:            "hosted.page.link",
 	DynamicLinkDomain:     "custom.page.link",
 	IOSBundleID:           "com.example.ios",
 	AndroidPackageName:    "com.example.android",
@@ -44,6 +45,7 @@ var testActionCodeSettings = &ActionCodeSettings{
 var testActionCodeSettingsMap = map[string]interface{}{
 	"continueUrl":           "https://example.dynamic.link",
 	"canHandleCodeInApp":    true,
+	"linkDomain":            "hosted.page.link",
 	"dynamicLinkDomain":     "custom.page.link",
 	"iOSBundleId":           "com.example.ios",
 	"androidPackageName":    "com.example.android",


### PR DESCRIPTION
# About this change

Add the `LinkDomain` field to the `ActionCodeSettings` struct, this new field enables migrating off of firebase dynamic links, which is deprecated and will be unsupported soon. 

See issue https://github.com/firebase/firebase-admin-go/issues/681, and original PR https://github.com/firebase/firebase-admin-go/pull/682

Unit test is updated to check that `linkDomain` is set correctly in the action code settings map.

# What should reviewers focus on

I've created a branch `vs-patch-1-v4-15-2`, to be the target branch for this change. I don't want to update the `master` branch because that will muddy our ability to keep the master branch in sync with the original repository.

Plan for maintaining our fork is:
- Sync master, and ensure the latest commit on master matches the commit id of the latest release tag in the original repository
- Make a patch branch off of the master branch, named something like `<patch-name>-<release-version>`
- Apply our patch commit on top of the branch
- Create a release tag like `<release-version>-vspatch.1` (see [go module versioning](https://go.dev/doc/modules/version-numbers))
- Use the `replace` feature in go.mod to switch fl-core to our patched release version (see [using forked package import in go](https://stackoverflow.com/questions/14323872/using-forked-package-import-in-go))